### PR TITLE
Fixed the csspath method for the svg / path elements.

### DIFF
--- a/inspector.js
+++ b/inspector.js
@@ -65,7 +65,7 @@
 			cssId = ( el.id ) ? ( '#' + el.id ) : false;
 			
 			// Get node's CSS classes, replacing spaces with '.':
-			cssClass = ( el.className ) ? ( '.' + el.className.replace(/\s+/g,".") ) : '';
+			cssClass = ( el.getAttribute('class') ) ? ( '.' + el.getAttribute('class').replace(/\s+/g,".") ) : '';
 
 			// Build a unique identifier for this parent node:
 			if ( cssId ) {


### PR DESCRIPTION
If the element is a svg or a path, it fails while replacing the classname with the dot operator. So fixed this using element.getAttribute('class'). Tested in https://github.com. The logo is svg element.
